### PR TITLE
Add support for after_trace hook to server middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-## 1.2.2.ejacobs1 09/08/2020
+## 1.2.2.ejacobs2 09/08/2020
   * Add optional after_trace hook to ClientMiddleware
 
 ## 1.2.1 07/09/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-## 1.2.2.ejacobs2 09/08/2020
+## 1.2.2 09/08/2020
   * Add optional after_trace hook to ClientMiddleware
 
 ## 1.2.1 07/09/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-## 1.2.2 09/08/2020
+## 1.2.2.ejacobs1 09/08/2020
   * Add optional after_trace hook to ClientMiddleware
 
 ## 1.2.1 07/09/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 Changelog
 =========
+
+## 1.2.2 09/08/2020
+  * Add optional after_trace hook to ClientMiddleware
+
 ## 1.2.1 07/09/2020
   * Ensure child spans are nested under the root Sidekiq span in the trace
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-instrumentation (1.2.2.ejacobs1)
+    sidekiq-instrumentation (1.2.2.ejacobs2)
       opentracing (>= 0.3.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-instrumentation (1.2.2)
+    sidekiq-instrumentation (1.2.2.ejacobs1)
       opentracing (>= 0.3.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-instrumentation (1.2.1)
+    sidekiq-instrumentation (1.2.2)
       opentracing (>= 0.3.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-instrumentation (1.2.2.ejacobs2)
+    sidekiq-instrumentation (1.2.2)
       opentracing (>= 0.3.1)
 
 GEM

--- a/lib/sidekiq/tracer.rb
+++ b/lib/sidekiq/tracer.rb
@@ -12,19 +12,19 @@ module Sidekiq
   module Tracer
     class << self
       def instrument(tracer: OpenTracing.global_tracer, active_span: nil, after_trace: nil)
-        instrument_client(tracer: tracer, active_span: active_span, after_trace: after_trace)
+        instrument_client(tracer: tracer, active_span: active_span)
         instrument_server(tracer: tracer, active_span: active_span, after_trace: after_trace)
       end
 
-      def instrument_client(tracer: OpenTracing.global_tracer, active_span: nil, after_trace: nil)
+      def instrument_client(tracer: OpenTracing.global_tracer, active_span: nil)
         Sidekiq.configure_client do |config|
-          config.client_middleware { |chain| add_client_middleware(chain, tracer, active_span, after_trace) }
+          config.client_middleware { |chain| add_client_middleware(chain, tracer, active_span) }
         end
       end
 
       def instrument_server(tracer: OpenTracing.global_tracer, active_span: nil, after_trace: nil)
         Sidekiq.configure_server do |config|
-          config.client_middleware { |chain| add_client_middleware(chain, tracer, active_span, after_trace) }
+          config.client_middleware { |chain| add_client_middleware(chain, tracer, active_span) }
           config.server_middleware { |chain| add_server_middleware(chain, tracer, active_span, after_trace) }
         end
 
@@ -33,8 +33,8 @@ module Sidekiq
         Sidekiq::Testing.server_middleware { |chain| add_server_middleware(chain, tracer, active_span, after_trace) }
       end
 
-      def add_client_middleware(chain, tracer, active_span, after_trace)
-        chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer, active_span: active_span, after_trace: after_trace
+      def add_client_middleware(chain, tracer, active_span)
+        chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer, active_span: active_span
       end
 
       def add_server_middleware(chain, tracer, active_span, after_trace)

--- a/lib/sidekiq/tracer.rb
+++ b/lib/sidekiq/tracer.rb
@@ -11,34 +11,34 @@ require "sidekiq/tracer/server_middleware"
 module Sidekiq
   module Tracer
     class << self
-      def instrument(tracer: OpenTracing.global_tracer, active_span: nil)
-        instrument_client(tracer: tracer, active_span: active_span)
-        instrument_server(tracer: tracer, active_span: active_span)
+      def instrument(tracer: OpenTracing.global_tracer, active_span: nil, after_trace: nil)
+        instrument_client(tracer: tracer, active_span: active_span, after_trace: after_trace)
+        instrument_server(tracer: tracer, active_span: active_span, after_trace: after_trace)
       end
 
-      def instrument_client(tracer: OpenTracing.global_tracer, active_span: nil)
+      def instrument_client(tracer: OpenTracing.global_tracer, active_span: nil, after_trace: nil)
         Sidekiq.configure_client do |config|
-          config.client_middleware { |chain| add_client_middleware(chain, tracer, active_span) }
+          config.client_middleware { |chain| add_client_middleware(chain, tracer, active_span, after_trace) }
         end
       end
 
-      def instrument_server(tracer: OpenTracing.global_tracer, active_span: nil)
+      def instrument_server(tracer: OpenTracing.global_tracer, active_span: nil, after_trace: nil)
         Sidekiq.configure_server do |config|
-          config.client_middleware { |chain| add_client_middleware(chain, tracer, active_span) }
-          config.server_middleware { |chain| add_server_middleware(chain, tracer, active_span) }
+          config.client_middleware { |chain| add_client_middleware(chain, tracer, active_span, after_trace) }
+          config.server_middleware { |chain| add_server_middleware(chain, tracer, active_span, after_trace) }
         end
 
         return unless defined?(Sidekiq::Testing)
 
-        Sidekiq::Testing.server_middleware { |chain| add_server_middleware(chain, tracer, active_span) }
+        Sidekiq::Testing.server_middleware { |chain| add_server_middleware(chain, tracer, active_span, after_trace) }
       end
 
-      def add_client_middleware(chain, tracer, active_span)
-        chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer, active_span: active_span
+      def add_client_middleware(chain, tracer, active_span, after_trace)
+        chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer, active_span: active_span, after_trace: after_trace
       end
 
-      def add_server_middleware(chain, tracer, active_span)
-        chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer, active_span: active_span
+      def add_server_middleware(chain, tracer, active_span, after_trace)
+        chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer, active_span: active_span, after_trace: after_trace
       end
     end
   end

--- a/lib/sidekiq/tracer/client_middleware.rb
+++ b/lib/sidekiq/tracer/client_middleware.rb
@@ -5,12 +5,11 @@ module Sidekiq
     class ClientMiddleware
       include Commons
 
-      attr_reader :tracer, :active_span, :after_trace
+      attr_reader :tracer, :active_span
 
-      def initialize(tracer:, active_span:, after_trace:)
+      def initialize(tracer:, active_span:)
         @tracer = tracer
         @active_span = active_span
-        @after_trace = after_trace
       end
 
       def call(_worker_class, job, _queue, _redis_pool)
@@ -23,7 +22,6 @@ module Sidekiq
         tag_errors(span, e) if span
         raise
       ensure
-        after_trace&.call(span) if span
         span&.finish
       end
 

--- a/lib/sidekiq/tracer/client_middleware.rb
+++ b/lib/sidekiq/tracer/client_middleware.rb
@@ -5,11 +5,12 @@ module Sidekiq
     class ClientMiddleware
       include Commons
 
-      attr_reader :tracer, :active_span
+      attr_reader :tracer, :active_span, :after_trace
 
-      def initialize(tracer:, active_span:)
+      def initialize(tracer:, active_span:, after_trace:)
         @tracer = tracer
         @active_span = active_span
+        @after_trace = after_trace
       end
 
       def call(_worker_class, job, _queue, _redis_pool)
@@ -22,6 +23,7 @@ module Sidekiq
         tag_errors(span, e) if span
         raise
       ensure
+        after_trace&.call(span) if span
         span&.finish
       end
 

--- a/lib/sidekiq/tracer/server_middleware.rb
+++ b/lib/sidekiq/tracer/server_middleware.rb
@@ -5,11 +5,12 @@ module Sidekiq
     class ServerMiddleware
       include Commons
 
-      attr_reader :tracer, :active_span
+      attr_reader :tracer, :active_span, :after_trace
 
-      def initialize(tracer:, active_span:)
+      def initialize(tracer:, active_span:, after_trace:)
         @tracer = tracer
         @active_span = active_span
+        @after_trace = after_trace
       end
 
       # rubocop:disable Metrics/MethodLength
@@ -27,6 +28,8 @@ module Sidekiq
           rescue StandardError => e
             tag_errors(scope.span, e) if scope.span
             raise
+          ensure
+            after_trace&.call(scope.span) if scope.span
           end
         end
       end

--- a/lib/sidekiq/tracer/version.rb
+++ b/lib/sidekiq/tracer/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Tracer
-    VERSION = "1.2.2"
+    VERSION = "1.2.2.ejacobs1"
   end
 end

--- a/lib/sidekiq/tracer/version.rb
+++ b/lib/sidekiq/tracer/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Tracer
-    VERSION = "1.2.2.ejacobs1"
+    VERSION = "1.2.2.ejacobs2"
   end
 end

--- a/lib/sidekiq/tracer/version.rb
+++ b/lib/sidekiq/tracer/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Tracer
-    VERSION = "1.2.1"
+    VERSION = "1.2.2"
   end
 end

--- a/lib/sidekiq/tracer/version.rb
+++ b/lib/sidekiq/tracer/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Tracer
-    VERSION = "1.2.2.ejacobs2"
+    VERSION = "1.2.2"
   end
 end

--- a/spec/sidekiq/tracer/server_middleware_spec.rb
+++ b/spec/sidekiq/tracer/server_middleware_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe Sidekiq::Tracer::ServerMiddleware do
     end
   end
 
+  describe "after trace hook" do
+    it "calls hook if defined" do
+      after_trace = double("after_trace")
+      expect(after_trace).to receive(:call)
+
+      schedule_test_job
+      Sidekiq::Tracer.instrument_server(tracer: tracer, after_trace: after_trace)
+      TestJob.drain
+    end
+  end
+
   describe "trace context propagation" do
     let(:root_span) { tracer.start_span("root") }
 
@@ -63,12 +74,9 @@ RSpec.describe Sidekiq::Tracer::ServerMiddleware do
   def schedule_test_job
     TestJob.perform_async("value1", "value2", 1)
   end
-
-  # rubocop:disable RSpec/LeakyConstantDeclaration
   class TestJob
     include Sidekiq::Worker
 
     def perform(*args); end
   end
-  # rubocop:enable RSpec/LeakyConstantDeclaration
 end

--- a/spec/sidekiq/tracer/server_middleware_spec.rb
+++ b/spec/sidekiq/tracer/server_middleware_spec.rb
@@ -48,13 +48,10 @@ RSpec.describe Sidekiq::Tracer::ServerMiddleware do
     end
   end
 
-  # The double in this test is standing in for a lambda, so it doesn't make a
-  # ton of sense to use a verified double here. Disabling the verified doubles
-  # cop
-  # rubocop:disable RSpec/VerifiedDoubles
   describe "after trace hook" do
     it "calls hook if defined" do
-      after_trace = spy("after_trace")
+      after_trace = Object.new
+      allow(after_trace).to receive(:call)
 
       schedule_test_job
       Sidekiq::Tracer.instrument_server(tracer: tracer, after_trace: after_trace)
@@ -63,7 +60,6 @@ RSpec.describe Sidekiq::Tracer::ServerMiddleware do
       expect(after_trace).to have_received(:call)
     end
   end
-  # rubocop:enable RSpec/VerifiedDoubles
 
   describe "trace context propagation" do
     let(:root_span) { tracer.start_span("root") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,13 +9,19 @@ require "sidekiq/tracer"
 # to avoid forking and updating the test-tracer gem to handle the latest version of OpenTracing
 # rubocop:disable Metrics/ParameterLists, Lint/UnusedMethodArgument, Layout/LineLength
 module TestTracerUpdates
+  class FakeScope
+    attr_accessor :span
+    def initialize(span)
+      @span = span
+    end
+  end
+
   def start_span(operation_name, child_of: nil, references: nil, start_time: Time.now, tags: nil, ignore_active_scope: false)
     super(operation_name, child_of: child_of, references: references, start_time: start_time, tags: tags)
   end
 
   def start_active_span(operation_name, child_of: nil, references: nil, start_time: Time.now, tags: nil, ignore_active_scope: false)
-    start_span(operation_name, child_of: child_of, references: references, start_time: start_time, tags: tags)
-    yield
+    yield FakeScope.new(start_span(operation_name, child_of: child_of, references: references, start_time: start_time, tags: tags))
   end
 end
 Test::Tracer.prepend TestTracerUpdates


### PR DESCRIPTION
Pivotal Story: https://www.pivotaltracker.com/story/show/174493567

after_trace allows the caller of the server middleware to define a lambda to execute after a sidekiq trace has occurred. We're using this in dox-tracing to allow sub-spans to set tags on top level spans (see Dox::Tracing::IngressTags)