### PR TITLE
Remove follows from relationship between sidekiq producer and consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 Changelog
 =========
+## 2.2.0 07/06/2023
+  * Stop using the follows from relationship for sidekiq job executions
+
 ## 2.1.0 11/29/2022
   * Fix compatibility issues in server & client middleware by removing deprecated #log in favor of #log_kv
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-instrumentation (2.1.0)
+    sidekiq-instrumentation (2.2.0)
       opentracing (>= 0.3.1)
 
 GEM

--- a/lib/sidekiq/tracer/client_middleware.rb
+++ b/lib/sidekiq/tracer/client_middleware.rb
@@ -29,7 +29,6 @@ module Sidekiq
 
       def build_span(job)
         tracer.start_span(operation_name(job),
-                          child_of: active_span.respond_to?(:call) ? active_span.call : active_span,
                           tags: tags(job, "producer"))
       end
 

--- a/lib/sidekiq/tracer/server_middleware.rb
+++ b/lib/sidekiq/tracer/server_middleware.rb
@@ -15,12 +15,7 @@ module Sidekiq
 
       # rubocop:disable Metrics/MethodLength
       def call(_worker, job, _queue)
-        parent_span_context = extract(job)
-
-        follows_from = OpenTracing::Reference.follows_from(parent_span_context)
-
         tracer.start_active_span(operation_name(job),
-                                 references: [follows_from],
                                  ignore_active_scope: true,
                                  tags: tags(job, "consumer")) do |scope|
           begin
@@ -40,13 +35,6 @@ module Sidekiq
       def tag_errors(span, error)
         span.set_tag("error", true)
         span.log_kv(**{ event: "error", 'error.object': error })
-      end
-
-      def extract(job)
-        carrier = job[TRACE_CONTEXT_KEY]
-        return unless carrier
-
-        tracer.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
       end
     end
   end

--- a/lib/sidekiq/tracer/version.rb
+++ b/lib/sidekiq/tracer/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Tracer
-    VERSION = "2.1.0"
+    VERSION = "2.2.0"
   end
 end

--- a/spec/sidekiq/tracer/client_middleware_spec.rb
+++ b/spec/sidekiq/tracer/client_middleware_spec.rb
@@ -51,24 +51,6 @@ RSpec.describe Sidekiq::Tracer::ClientMiddleware do
     end
   end
 
-  describe "active span propagation" do
-    let(:root_span) { tracer.start_span("root") }
-
-    before do
-      Sidekiq::Tracer.instrument_client(tracer: tracer, active_span: -> { root_span })
-      schedule_test_job
-    end
-
-    it "creates the new span with active span trace_id" do
-      expect(tracer).to have_traces(1)
-      expect(tracer).to have_spans(2)
-    end
-
-    it "creates the new span with active span as a parent" do
-      expect(tracer).to have_span.with_parent(root_span)
-    end
-  end
-
   describe "span context injection" do
     before do
       Sidekiq::Tracer.instrument_client(tracer: tracer)

--- a/spec/sidekiq/tracer/server_middleware_spec.rb
+++ b/spec/sidekiq/tracer/server_middleware_spec.rb
@@ -74,10 +74,6 @@ RSpec.describe Sidekiq::Tracer::ServerMiddleware do
     it "creates spans for each part of the chain" do
       expect(tracer).to have_spans(3)
     end
-
-    it "creates separate traces for the producer and consumer" do
-      expect(tracer).to have_traces(2)
-    end
   end
 
   def schedule_test_job


### PR DESCRIPTION
According to the Open Tracing data model docs
> A message bus is asynchronous, and therefore the relationship type used to link a Consumer Span and a Producer Span would be Follows From (see [References between Spans](https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans) for more information on relationship types).

https://github.com/opentracing/specification/blob/master/semantic_conventions.md#message-bus

Semantically this is the correct way to define this data, but in the tools that visualize traces trying to keep producer and consumer in the same trace makes the data a lot harder to work with.  Vendors might process this differently but Lightstep says they treat follows from like the parent child span relationship. 